### PR TITLE
Update ByProjectKeyInStoreKeyByStoreKeyCartsGet

### DIFF
--- a/commercetools.Sdk/commercetools.Sdk.Api/Generated/Client/RequestBuilders/InStore/ByProjectKeyInStoreKeyByStoreKeyCartsGet.cs
+++ b/commercetools.Sdk/commercetools.Sdk.Api/Generated/Client/RequestBuilders/InStore/ByProjectKeyInStoreKeyByStoreKeyCartsGet.cs
@@ -103,10 +103,10 @@ namespace commercetools.Api.Client.RequestBuilders.InStore
             return this.AddQueryParam($"var.{varName}", predicateVar);
         }
 
-        public async Task<Object> ExecuteAsync()
+        public async Task<commercetools.Api.Models.Carts.ICartPagedQueryResponse> ExecuteAsync()
         {
             var requestMessage = Build();
-            return await ApiHttpClient.ExecuteAsync<Object>(requestMessage);
+            return await ApiHttpClient.ExecuteAsync<commercetools.Api.Models.Carts.ICartPagedQueryResponse>(requestMessage);
         }
 
     }


### PR DESCRIPTION
Change result from ExecuteAsync from `object` to `commercetools.Api.Models.Carts.ICartPagedQueryResponse` so it can be used.

As by just returning an object you can do anything with it as Deserializing does work due use of all the interfaces and the return type for ExecuteAsync matches similar classes.